### PR TITLE
Add a DQ command for the bad children

### DIFF
--- a/local-types/moment-timer/index.d.ts
+++ b/local-types/moment-timer/index.d.ts
@@ -3,37 +3,37 @@ import moment from 'moment';
 export = moment;
 
 declare module 'moment' {
-	interface TimerAttributes {
-		/** Setting this attribute to `true` will cause the timer to start once instantiated. */
-		start?: boolean;
-		/** Setting this attribute to `true` will cause the timer to loop/reset once a duration is complete. */
-		loop?: boolean;
-		/** Setting this attribute will cause the time to wait for a specified amount of time before starting its duration. */
-		wait?: number | Duration;
-		/** Setting this attribute to `true` will cause the callback to be called after the wait duration has ended. */
-		executeAfterWait?: boolean;
-	}
+  interface TimerAttributes {
+    /** Setting this attribute to `true` will cause the timer to start once instantiated. */
+    start?: boolean;
+    /** Setting this attribute to `true` will cause the timer to loop/reset once a duration is complete. */
+    loop?: boolean;
+    /** Setting this attribute will cause the time to wait for a specified amount of time before starting its duration. */
+    wait?: number | Duration;
+    /** Setting this attribute to `true` will cause the callback to be called after the wait duration has ended. */
+    executeAfterWait?: boolean;
+  }
 
-	interface Timer {
-		/** Start the timer. This can be used if the start attribute has not been set or if the timer has been stopped. */
-		start(): boolean;
-		/** Stop the timer. */
-		stop(): boolean;
+  interface Timer {
+    /** Start the timer. This can be used if the start attribute has not been set or if the timer has been stopped. */
+    start(): boolean;
+    /** Stop the timer. */
+    stop(): boolean;
 
-		/** Change the timer's duration. */
-		duration(duration: number | Duration): boolean;
-		/** Get the current duration of the timer. */
-		getDuration(): Duration;
-		/** Get the remaining duration of the timer's cycle. */
-		getRemainingDuration(): Duration;
-		
-		/** Check whether the timer is stopped. */
-		isStopped(): boolean;
-		/** Check whether the timer is running. */
-		isStarted(): boolean;
-	}
+    /** Change the timer's duration. */
+    duration(duration: number | Duration): boolean;
+    /** Get the current duration of the timer. */
+    getDuration(): Duration;
+    /** Get the remaining duration of the timer's cycle. */
+    getRemainingDuration(): Duration;
 
-	interface Duration {
-		timer(attributes: TimerAttributes, callback: Function): Timer;
-	}
+    /** Check whether the timer is stopped. */
+    isStopped(): boolean;
+    /** Check whether the timer is running. */
+    isStarted(): boolean;
+  }
+
+  interface Duration {
+    timer(attributes: TimerAttributes, callback: Function): Timer;
+  }
 }

--- a/local-types/moment-timer/index.d.ts
+++ b/local-types/moment-timer/index.d.ts
@@ -1,0 +1,39 @@
+import moment from 'moment';
+
+export = moment;
+
+declare module 'moment' {
+	interface TimerAttributes {
+		/** Setting this attribute to `true` will cause the timer to start once instantiated. */
+		start?: boolean;
+		/** Setting this attribute to `true` will cause the timer to loop/reset once a duration is complete. */
+		loop?: boolean;
+		/** Setting this attribute will cause the time to wait for a specified amount of time before starting its duration. */
+		wait?: number | Duration;
+		/** Setting this attribute to `true` will cause the callback to be called after the wait duration has ended. */
+		executeAfterWait?: boolean;
+	}
+
+	interface Timer {
+		/** Start the timer. This can be used if the start attribute has not been set or if the timer has been stopped. */
+		start(): boolean;
+		/** Stop the timer. */
+		stop(): boolean;
+
+		/** Change the timer's duration. */
+		duration(duration: number | Duration): boolean;
+		/** Get the current duration of the timer. */
+		getDuration(): Duration;
+		/** Get the remaining duration of the timer's cycle. */
+		getRemainingDuration(): Duration;
+		
+		/** Check whether the timer is stopped. */
+		isStopped(): boolean;
+		/** Check whether the timer is running. */
+		isStarted(): boolean;
+	}
+
+	interface Duration {
+		timer(attributes: TimerAttributes, callback: Function): Timer;
+	}
+}

--- a/local-types/moment-timer/package.json
+++ b/local-types/moment-timer/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@types/moment-timer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,10 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/moment-timer": {
+      "version": "file:local-types/moment-timer",
+      "dev": true
+    },
     "@types/mongodb": {
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.16.tgz",
@@ -2497,6 +2501,19 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "moment": {
+      "version": "2.25.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
+      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
+    },
+    "moment-timer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/moment-timer/-/moment-timer-1.3.0.tgz",
+      "integrity": "sha512-zS05L5RRhpeTjLCblgfJVTZ7WoqRlV8ksv75UHJSsUBsm09FhDZjL6vaDyPW9MsWVTCEthAesYOQ7I1CfV+90Q==",
+      "requires": {
+        "moment": ">= 1.6.0"
       }
     },
     "mongodb": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@discordjs/opus": "^0.2.1",
     "discord.js": "^12.2.0",
     "googleapis": "^49.0.0",
+    "moment": "^2.25.3",
+    "moment-timer": "^1.3.0",
     "mongodb": "^3.5.6",
     "ytdl-core": "^2.1.1"
   },
@@ -38,6 +40,7 @@
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.31.0",
     "@typescript-eslint/parser": "^2.31.0",
+    "@types/moment-timer": "file:./local-types/moment-timer",
     "eslint": "^6.8.0",
     "nodemon": "^2.0.3",
     "ts-node": "^8.10.1",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "ytdl-core": "^2.1.1"
   },
   "devDependencies": {
+    "@types/moment-timer": "file:./local-types/moment-timer",
     "@types/mongodb": "^3.5.15",
     "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.31.0",
     "@typescript-eslint/parser": "^2.31.0",
-    "@types/moment-timer": "file:./local-types/moment-timer",
     "eslint": "^6.8.0",
     "nodemon": "^2.0.3",
     "ts-node": "^8.10.1",

--- a/src/commands/dq.ts
+++ b/src/commands/dq.ts
@@ -4,46 +4,51 @@ import 'moment-timer';
 import { Collection, Guild, GuildMember, Message, MessageEmbed, TextChannel, User } from 'discord.js';
 import { Command, db } from '..';
 
-const duration_regex = /[0-9]+|(y|M|w|d|h|n|s|ms)/;
+const durationRegex = /[0-9]+|(y|M|w|d|h|n|s|ms)/;
 
 const verifiedRoleId = '260524994646376449';
 const timeoutRoleId = '392860547626041345';
 const timeoutChannelId = '392860089951846400';
 
-const doTimeout = async (guild: Guild, dispatcher: {member: GuildMember, user: User}, members: Collection<string, GuildMember>, duration: moment.Duration, reason?: string) => {
-	const channel = guild.channels.cache.get(timeoutChannelId) as TextChannel;
+const doTimeout = async (
+  guild: Guild,
+  dispatcher: {member: GuildMember; user: User},
+  members: Collection<string, GuildMember>,
+  duration: moment.Duration,
+  reason?: string): Promise<void> => {
+  const channel = guild.channels.cache.get(timeoutChannelId) as TextChannel;
 	
-	const membersStr = members.map(m => `${m}`).join('\n');
+  const membersStr = members.map(m => `${m}`).join('\n');
 
-	// remove verified role and add DQ role for all mentioned members that are not already DQ'd
-	await Promise.all(
-		[...members.filter(member => !member.roles.cache.has(timeoutRoleId)).values()].flatMap(member => [
-			member.roles.remove(verifiedRoleId, 'DQ'),
-			member.roles.add(timeoutRoleId, 'DQ')
-		]));
+  // remove verified role and add DQ role for all mentioned members that are not already DQ'd
+  await Promise.all(
+    [...members.filter(member => !member.roles.cache.has(timeoutRoleId)).values()].flatMap(member => [
+      member.roles.remove(verifiedRoleId, 'DQ'),
+      member.roles.add(timeoutRoleId, 'DQ')
+    ]));
 
 	
-	channel.send(`<@&${timeoutRoleId}>:`);
-	const announcement = new MessageEmbed()
-		.setAuthor(dispatcher.member.displayName, dispatcher.user.displayAvatarURL(), `https://discordapp.com/users/${dispatcher.user.id}`)
-		.setTitle('Disqualification')
-		.setThumbnail('https://discordapp.com/assets/8e9a2d7ef44c1052a246e062e4c3f796.svg') // :checkered_flag:
-		.addField('Reason', reason || 'unspecified')
-		.addField('Duration', duration.humanize())
-		.addField('Affected users', membersStr)
+  channel.send(`<@&${timeoutRoleId}>:`);
+  const announcement = new MessageEmbed()
+    .setAuthor(dispatcher.member.displayName, dispatcher.user.displayAvatarURL(), `https://discordapp.com/users/${dispatcher.user.id}`)
+    .setTitle('Disqualification')
+    .setThumbnail('https://discordapp.com/assets/8e9a2d7ef44c1052a246e062e4c3f796.svg') // :checkered_flag:
+    .addField('Reason', reason || 'unspecified')
+    .addField('Duration', duration.humanize())
+    .addField('Affected users', membersStr);
 
-	channel.send(announcement);
+  channel.send(announcement);
 };
 
-export const doUnTimeout = (member: GuildMember) => async () => {
-	await Promise.all([
-		member.roles.remove(timeoutRoleId, 'DQ over'),
-		member.roles.add(verifiedRoleId, 'DQ over')
-	]);
+export const doUnTimeout = (member: GuildMember) => async (): Promise<void> => {
+  await Promise.all([
+    member.roles.remove(timeoutRoleId, 'DQ over'),
+    member.roles.add(verifiedRoleId, 'DQ over')
+  ]);
 };
 
 class DqCommand implements Command {
-	/**
+  /**
 	  * format: <prefix> dq \S <duration> <mentions> ( \S <reason> )?
 	  *  where:
 	  *		<duration>: [0-9]+ <unit>
@@ -51,46 +56,46 @@ class DqCommand implements Command {
 	  *		<mentions>: <mention> ( \S <mention> )*
 	  *		  <reason>: .+
 	  */
-	async execute(message: Message, args: string): Promise<Message> {
-		if (!message.guild) {
-			return message.reply('that command is only available in servers.');
-		}
-		if (!message.member.hasPermission('ADMINISTRATOR')) {
-			return message.reply('you must be an administrator to use that command');
-		}
+  async execute(message: Message, args: string): Promise<Message> {
+    if (!message.guild) {
+      return message.reply('that command is only available in servers.');
+    }
+    if (!message.member.hasPermission('ADMINISTRATOR')) {
+      return message.reply('you must be an administrator to use that command');
+    }
 		
-		// strip @-mentions out of the args string because we just care about the duration and reason
-		args = args.split(' ').filter(e => !e.startsWith('@')).join(' ');
-		const [duration_str, reason] = args.split(' ', 2);
+    // strip @-mentions out of the args string because we just care about the duration and reason
+    args = args.split(' ').filter(e => !e.startsWith('@')).join(' ');
+    const [durationStr, reason] = args.split(' ', 2);
 
-		// make sure that the user only gives a valid shorthand duration specifier. moment doesn't check this properly still (see moment/moment#1805)
-		if (duration_str.match(duration_regex).length !== 2) {
-			return message.reply(`invalid duration \`${duration_str}\`. valid units are \`y\`, \`M\`, \`w\`, \`d\`, \`h\`, \`m\`, \`s\`, and \`ms\`.`);
-		}
+    // make sure that the user only gives a valid shorthand duration specifier. moment doesn't check this properly still (see moment/moment#1805)
+    if (durationStr.match(durationRegex).length !== 2) {
+      return message.reply(`invalid duration \`${durationStr}\`. valid units are \`y\`, \`M\`, \`w\`, \`d\`, \`h\`, \`m\`, \`s\`, and \`ms\`.`);
+    }
 
 
-		//message.mentions.members.forEach(do_timeout(message.guild));
+    //message.mentions.members.forEach(do_timeout(message.guild));
 		
-		const duration = moment.duration(...duration_str.match(duration_regex));
-		duration.timer({start: true}, doUnTimeout);
-		const dqEndTime = moment().add(duration).valueOf();
+    const duration = moment.duration(...durationStr.match(durationRegex));
+    duration.timer({start: true}, doUnTimeout);
+    const dqEndTime = moment().add(duration).valueOf();
 
-		doTimeout(message.guild, {member: message.member, user: message.author}, message.mentions.members, duration, reason);
+    doTimeout(message.guild, {member: message.member, user: message.author}, message.mentions.members, duration, reason);
 
-		await db().collection('dqs').updateMany({
-			_id: {
-				guild: message.guild.id,
-				channel: message.channel.id,
-				user: { $in: message.mentions.users.map(u => u.id) }
-			}
-		}, {
-			$set: { dqEndTime }
-		}, {
-			upsert: true
-		});
+    await db().collection('dqs').updateMany({
+      _id: {
+        guild: message.guild.id,
+        channel: message.channel.id,
+        user: { $in: message.mentions.users.map(u => u.id) }
+      }
+    }, {
+      $set: { dqEndTime }
+    }, {
+      upsert: true
+    });
 
-		// TODO: send message to channel
-	}
+    // TODO: send message to channel
+  }
 }
 
 export default new DqCommand();

--- a/src/commands/dq.ts
+++ b/src/commands/dq.ts
@@ -1,10 +1,19 @@
+import { Collection, Guild, GuildMember, Message, MessageEmbed, MessageMentions, Permissions, TextChannel } from 'discord.js';
 import moment from 'moment';
 import 'moment-timer';
+import { BulkWriteOperation } from 'mongodb';
 
-import { Collection, Guild, GuildMember, Message, MessageEmbed, TextChannel, User } from 'discord.js';
-import { Command, db } from '..';
+import { Command, db, userUrl } from '..';
 
-const durationRegex = /[0-9]+|(y|M|w|d|h|n|s|ms)/;
+export type Dq = {
+  _id: {
+    guild: string;
+    user: string;
+  };
+  dqEndTime: number;
+};
+
+const durationRegex = /^([0-9]+)\s*(y|M|w|d|h|m|s|ms)$/;
 
 const verifiedRoleId = '260524994646376449';
 const timeoutRoleId = '392860547626041345';
@@ -12,12 +21,12 @@ const timeoutChannelId = '392860089951846400';
 
 const doTimeout = async (
   guild: Guild,
-  dispatcher: {member: GuildMember; user: User},
+  dispatcher: GuildMember,
   members: Collection<string, GuildMember>,
   duration: moment.Duration,
   reason?: string): Promise<void> => {
   const channel = guild.channels.cache.get(timeoutChannelId) as TextChannel;
-	
+
   const membersStr = members.map(m => `${m}`).join('\n');
 
   // remove verified role and add DQ role for all mentioned members that are not already DQ'd
@@ -27,17 +36,14 @@ const doTimeout = async (
       member.roles.add(timeoutRoleId, 'DQ')
     ]));
 
-	
-  channel.send(`<@&${timeoutRoleId}>:`);
   const announcement = new MessageEmbed()
-    .setAuthor(dispatcher.member.displayName, dispatcher.user.displayAvatarURL(), `https://discordapp.com/users/${dispatcher.user.id}`)
+    .setAuthor(dispatcher.displayName, dispatcher.user.displayAvatarURL(), userUrl(dispatcher.user.id))
     .setTitle('Disqualification')
-    .setThumbnail('https://discordapp.com/assets/8e9a2d7ef44c1052a246e062e4c3f796.svg') // :checkered_flag:
+    .setThumbnail('https://ton.twimg.com/stickers/stickers/10855_raw.png') // :checkered_flag:
     .addField('Reason', reason || 'unspecified')
     .addField('Duration', duration.humanize())
     .addField('Affected users', membersStr);
-
-  channel.send(announcement);
+  await channel.send(announcement);
 };
 
 export const doUnTimeout = (member: GuildMember) => async (): Promise<void> => {
@@ -49,50 +55,59 @@ export const doUnTimeout = (member: GuildMember) => async (): Promise<void> => {
 
 class DqCommand implements Command {
   /**
-	  * format: <prefix> dq \S <duration> <mentions> ( \S <reason> )?
-	  *  where:
-	  *		<duration>: [0-9]+ <unit>
-	  *		    <unit>: ( y | M | w | d | h | m | s | ms )
-	  *		<mentions>: <mention> ( \S <mention> )*
-	  *		  <reason>: .+
-	  */
+   * format: <prefix> dq \S <duration> <mentions> ( \S <reason> )?
+   *  where:
+   *    <duration>: [0-9]+ <unit>
+   *        <unit>: ( y | M | w | d | h | m | s | ms )
+   *    <mentions>: <mention> ( \S <mention> )*
+   *      <reason>: .+
+   */
   async execute(message: Message, args: string): Promise<Message> {
     if (!message.guild) {
       return message.reply('that command is only available in servers.');
     }
-    if (!message.member.hasPermission('ADMINISTRATOR')) {
-      return message.reply('you must be an administrator to use that command');
+    if (!message.member.hasPermission(Permissions.FLAGS.MANAGE_ROLES)) {
+      return message.reply('you must have the Manage Roles permission to use that command.');
     }
-		
+    if (message.member.roles.highest.comparePositionTo(message.guild.roles.resolve(timeoutRoleId)) <= 0) {
+      return message.reply(`you must have a role higher than <@&${timeoutRoleId}> to use that command.`);
+    }
+    if (!message.mentions.members.size) {
+      return message.reply('you must mention at least one member to DQ.');
+    }
+
     // strip @-mentions out of the args string because we just care about the duration and reason
-    args = args.split(' ').filter(e => !e.startsWith('@')).join(' ');
-    const [durationStr, reason] = args.split(' ', 2);
+    const [durationStr, ...reasonArr] = args.trim().split(/\s+/).filter(e => !MessageMentions.USERS_PATTERN.test(e));
+    const reason = reasonArr.join(' ');
 
     // make sure that the user only gives a valid shorthand duration specifier. moment doesn't check this properly still (see moment/moment#1805)
-    if (durationStr.match(durationRegex).length !== 2) {
+    const matches = durationStr.match(durationRegex)?.slice(1, 3);
+    if (matches?.length !== 2) {
       return message.reply(`invalid duration \`${durationStr}\`. valid units are \`y\`, \`M\`, \`w\`, \`d\`, \`h\`, \`m\`, \`s\`, and \`ms\`.`);
     }
 
-
-    //message.mentions.members.forEach(do_timeout(message.guild));
-		
-    const duration = moment.duration(...durationStr.match(durationRegex));
-    duration.timer({start: true}, doUnTimeout);
+    const duration = moment.duration(...matches);
+    duration.timer({start: true}, () => message.mentions.members.forEach(m => doUnTimeout(m)()));
     const dqEndTime = moment().add(duration).valueOf();
 
-    doTimeout(message.guild, {member: message.member, user: message.author}, message.mentions.members, duration, reason);
+    await doTimeout(message.guild, message.member, message.mentions.members, duration, reason);
 
-    await db().collection('dqs').updateMany({
-      _id: {
-        guild: message.guild.id,
-        channel: message.channel.id,
-        user: { $in: message.mentions.users.map(u => u.id) }
-      }
-    }, {
-      $set: { dqEndTime }
-    }, {
-      upsert: true
-    });
+    await db().collection<Dq>('dqs').bulkWrite(message.mentions.users.map<BulkWriteOperation<Dq>>(u => {
+      return {
+        updateOne: {
+          filter: {
+            _id: {
+              guild: message.guild.id,
+              user: u.id
+            }
+          },
+          update: {
+            $set: { dqEndTime }
+          },
+          upsert: true
+        }
+      };
+    }));
 
     // TODO: send message to channel
   }

--- a/src/commands/dq.ts
+++ b/src/commands/dq.ts
@@ -1,0 +1,96 @@
+import moment from 'moment';
+import 'moment-timer';
+
+import { Collection, Guild, GuildMember, Message, MessageEmbed, TextChannel, User } from 'discord.js';
+import { Command, db } from '..';
+
+const duration_regex = /[0-9]+|(y|M|w|d|h|n|s|ms)/;
+
+const verifiedRoleId = '260524994646376449';
+const timeoutRoleId = '392860547626041345';
+const timeoutChannelId = '392860089951846400';
+
+const doTimeout = async (guild: Guild, dispatcher: {member: GuildMember, user: User}, members: Collection<string, GuildMember>, duration: moment.Duration, reason?: string) => {
+	const channel = guild.channels.cache.get(timeoutChannelId) as TextChannel;
+	
+	const membersStr = members.map(m => `${m}`).join('\n');
+
+	// remove verified role and add DQ role for all mentioned members that are not already DQ'd
+	await Promise.all(
+		[...members.filter(member => !member.roles.cache.has(timeoutRoleId)).values()].flatMap(member => [
+			member.roles.remove(verifiedRoleId, 'DQ'),
+			member.roles.add(timeoutRoleId, 'DQ')
+		]));
+
+	
+	channel.send(`<@&${timeoutRoleId}>:`);
+	const announcement = new MessageEmbed()
+		.setAuthor(dispatcher.member.displayName, dispatcher.user.displayAvatarURL(), `https://discordapp.com/users/${dispatcher.user.id}`)
+		.setTitle('Disqualification')
+		.setThumbnail('https://discordapp.com/assets/8e9a2d7ef44c1052a246e062e4c3f796.svg') // :checkered_flag:
+		.addField('Reason', reason || 'unspecified')
+		.addField('Duration', duration.humanize())
+		.addField('Affected users', membersStr)
+
+	channel.send(announcement);
+};
+
+export const doUnTimeout = (member: GuildMember) => async () => {
+	await Promise.all([
+		member.roles.remove(timeoutRoleId, 'DQ over'),
+		member.roles.add(verifiedRoleId, 'DQ over')
+	]);
+};
+
+class DqCommand implements Command {
+	/**
+	  * format: <prefix> dq \S <duration> <mentions> ( \S <reason> )?
+	  *  where:
+	  *		<duration>: [0-9]+ <unit>
+	  *		    <unit>: ( y | M | w | d | h | m | s | ms )
+	  *		<mentions>: <mention> ( \S <mention> )*
+	  *		  <reason>: .+
+	  */
+	async execute(message: Message, args: string): Promise<Message> {
+		if (!message.guild) {
+			return message.reply('that command is only available in servers.');
+		}
+		if (!message.member.hasPermission('ADMINISTRATOR')) {
+			return message.reply('you must be an administrator to use that command');
+		}
+		
+		// strip @-mentions out of the args string because we just care about the duration and reason
+		args = args.split(' ').filter(e => !e.startsWith('@')).join(' ');
+		const [duration_str, reason] = args.split(' ', 2);
+
+		// make sure that the user only gives a valid shorthand duration specifier. moment doesn't check this properly still (see moment/moment#1805)
+		if (duration_str.match(duration_regex).length !== 2) {
+			return message.reply(`invalid duration \`${duration_str}\`. valid units are \`y\`, \`M\`, \`w\`, \`d\`, \`h\`, \`m\`, \`s\`, and \`ms\`.`);
+		}
+
+
+		//message.mentions.members.forEach(do_timeout(message.guild));
+		
+		const duration = moment.duration(...duration_str.match(duration_regex));
+		duration.timer({start: true}, doUnTimeout);
+		const dqEndTime = moment().add(duration).valueOf();
+
+		doTimeout(message.guild, {member: message.member, user: message.author}, message.mentions.members, duration, reason);
+
+		await db().collection('dqs').updateMany({
+			_id: {
+				guild: message.guild.id,
+				channel: message.channel.id,
+				user: { $in: message.mentions.users.map(u => u.id) }
+			}
+		}, {
+			$set: { dqEndTime }
+		}, {
+			upsert: true
+		});
+
+		// TODO: send message to channel
+	}
+}
+
+export default new DqCommand();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Client, ColorResolvable, Constants, Message, MessageEmbed, PartialMessage, TextChannel, GuildMember } from 'discord.js';
+import { Client, ColorResolvable, Constants, Message, MessageEmbed, PartialMessage, TextChannel } from 'discord.js';
 import moment from 'moment-timer';
 import { Db, MongoClient } from 'mongodb';
 import { inspect } from 'util';
@@ -59,22 +59,22 @@ export const addFooter = (message: Message, reply: Message): Promise<Message> =>
   return reply.edit(embed);
 };
 
-const reloadDQTimers = async (client: Client) => {
-	await Promise.all(await db().collection('dqs').find().map(document => {
-		const member = client.guilds.cache.get(document._id.guild).members.cache.get(document._id.user);
+const reloadDQTimers = async (client: Client): Promise<void> => {
+  await Promise.all(await db().collection('dqs').find().map(document => {
+    const member = client.guilds.cache.get(document._id.guild).members.cache.get(document._id.user);
 		
-		// check if timer has lapsed while the bot was off, and if so free the prisoner
-		if (moment().isSameOrAfter(moment(document.dqEndTime))) {
-			return doUnTimeout(member)();
-		}
+    // check if timer has lapsed while the bot was off, and if so free the prisoner
+    if (moment().isSameOrAfter(moment(document.dqEndTime))) {
+      return doUnTimeout(member)();
+    }
 
-		// still time left so just set the timers back up
-		moment.duration(moment().diff(moment(document.dqEndTime))).timer({start: true}, doUnTimeout(member));
-		return Promise.resolve();
-	}).toArray());
+    // still time left so just set the timers back up
+    moment.duration(moment().diff(moment(document.dqEndTime))).timer({start: true}, doUnTimeout(member));
+    return Promise.resolve();
+  }).toArray());
 };
 
-const loginPromiseForwarder = (fn: Function) => (token: string) => { fn(); return token; };
+const loginPromiseForwarder = (fn: Function) => (token: string): string => { fn(); return token; };
 
 const restart = (): Promise<string> => {
   client.destroy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "target": "es6",
+    "lib": [
+	"ES2019"
+    ],
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
Does what it says on the tin, plus a couple surprises.

The surprises:
- add a local package in order to provide a typescript declaration file for `moment-timer`. that's all it does. as a corollary to this:
- add dependencies on `moment` and `moment-timer`. these are used for the DQ timers
- add some logic to index.ts for reloading the timers if the bot restarts. as a corollary to _this_:
- add another collection to the mongo db (called `dqs`). finally:
- add the `es2019` library to the typescript compiler options. this is entirely so that i could use `flatMap` in one place. (see https://stackoverflow.com/a/53559473/3681958)

I'm not sure yet about adding the `dq` command to the command info list. the command itself should be properly gated to only those users who have admin permissions, but in my experience seeing something exists (regardless of whether it can be used or not) is.... tempting for some.

one solution would be to special-case it like `restart`. this would also involve holding onto a singleton instance of `DqCommand` probably (actually now that i think about it there's not really any state so it wouldn't need to be singleton).

another solution would be to make the help command more robust, showing certain options only to those with defined privilege levels (and maybe even only in certain channels).

the role and channel IDs aren't very configurable in this PR, but since that framework isn't in place for the rest of it yet I figured that wouldn't matter so much