### PR TITLE
Updated Moderation Commands and Moderation Logs

### DIFF
--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -24,7 +24,7 @@ export class BanCommand extends Command {
     }
     const user = interaction.options.getUser(Option.User, true);
     const reason = interaction.options.getString(Option.Reason);
-    let purge = interaction.options.getBoolean(Option.Purge);
+    const purge = interaction.options.getBoolean(Option.Purge);
 
     const guild = await interaction.client.guilds.fetch(interaction.guildId);
     const member = await guild.members.fetch(user);
@@ -43,10 +43,9 @@ export class BanCommand extends Command {
       });
       return;
     }
-    let purgeTime: number;
-    purgeTime = (!purge) ? 0 : 604800;
+    const purgeTime = (!purge) ? 0 : 604800;
 
-    const filter = { '_id.guild': interaction.guildId!, '_id.user': member.id };
+    const filter = { '_id.guild': interaction.guildId, '_id.user': member.id };
 
     const userBan: banLog = {
       date: new Date(),

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -1,0 +1,129 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Command, CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import {
+  EmbedBuilder,
+  PermissionFlagsBits,
+  type ChatInputCommandInteraction,
+} from 'discord.js';
+import { Color } from '../lib/embeds.js';
+import { messageLogger, moderationLogs } from '../index.js';
+import type { banLog } from '../lib/moderation.js';
+
+@ApplyOptions<Command.Options>({
+  description: 'Ban user',
+  requiredClientPermissions: [PermissionFlagsBits.BanMembers],
+  requiredUserPermissions: [PermissionFlagsBits.BanMembers],
+
+  runIn: [CommandOptionsRunTypeEnum.GuildAny],
+})
+export class BanCommand extends Command {
+
+  public override async chatInputRun(interaction: ChatInputCommandInteraction) {
+    if (!interaction.inGuild()) {
+      return;
+    }
+    const user = interaction.options.getUser(Option.User, true);
+    const reason = interaction.options.getString(Option.Reason);
+    let purge = interaction.options.getBoolean(Option.Purge);
+
+    const guild = await interaction.client.guilds.fetch(interaction.guildId);
+    const member = await guild.members.fetch(user);
+    if (!member) {
+      await interaction.reply({
+        content: `Error: ${user} is not a member of this server`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (!reason) {
+      await interaction.reply({
+        content: `Error: Timeouts require a reason.`,
+        ephemeral: true,
+      });
+      return;
+    }
+    let purgeTime: number;
+    purgeTime = (!purge) ? 0 : 604800;
+
+    const filter = { '_id.guild': interaction.guildId!, '_id.user': member.id };
+
+    const userBan: banLog = {
+      date: new Date(),
+      user: interaction.user.id,
+      reason: reason
+    };
+
+    const update = {
+      $push: {
+        ban: userBan
+      }
+    };
+
+    const options = { upsert: true };
+
+    moderationLogs.findOneAndUpdate(filter, update, options);
+
+    const embed = new EmbedBuilder()
+      .setColor(Color.Red)
+      .setTitle('You Have Been Banned')
+      .addFields(
+        { name: 'Server', value: `${guild.name}` },
+        { name: 'Reason', value: reason },
+      )
+      .setTimestamp(interaction.createdTimestamp);
+
+    await member.send({ embeds: [embed] });
+
+    await member.ban({ deleteMessageSeconds: purgeTime, reason: reason })
+
+    const ephemeralEmbed = new EmbedBuilder()
+      .setColor(Color.Red)
+      .setDescription(`${user.tag} banned`)
+
+    await interaction.reply({
+      embeds: [ephemeralEmbed],
+      ephemeral: true,
+    });
+
+    await messageLogger.logMemberBan(
+      member,
+      interaction.user,
+      reason,
+      interaction.createdTimestamp
+    );
+  }
+
+  public override registerApplicationCommands(registry: Command.Registry) {
+    registry.registerChatInputCommand(
+      command =>
+        command
+          .setName(this.name)
+          .setDescription(this.description)
+          .addUserOption(user =>
+            user
+              .setName(Option.User)
+              .setDescription('The user to timeout')
+              .setRequired(true)
+          )
+          .addStringOption(reason =>
+            reason
+              .setName(Option.Reason)
+              .setDescription('The reason for banning them')
+              .setRequired(true)
+          )
+          .addBooleanOption(purge =>
+            purge
+              .setName(Option.Purge)
+              .setDescription('Purge their messages?')
+          ),
+      { idHints: [] }
+    );
+  }
+}
+
+enum Option {
+  User = 'user',
+  Reason = 'reason',
+  Purge = 'purge',
+}

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -55,7 +55,7 @@ export class BanCommand extends Command {
 
     const update = {
       $push: {
-        ban: userBan
+        bans: userBan
       }
     };
 

--- a/src/commands/ban.ts
+++ b/src/commands/ban.ts
@@ -48,7 +48,7 @@ export class BanCommand extends Command {
 
     const update = {
       $push: {
-        bans: userBan
+        bans: { $each: [userBan], $position: 0 }
       }
     };
 

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -211,6 +211,8 @@ export class LogsCommand extends Command {
                 `<@${userLog.timeouts[index].user}>`,
                 bold('Date'),
                 userLog.timeouts[index].date,
+                bold('Duration'),
+                userLog.timeouts[index].duration,
                 bold('Reason'),
                 userLog.timeouts[index].reason,
             ].join('\n');

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,0 +1,321 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Command, CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import {
+    ActionRowBuilder,
+    bold,
+    ButtonBuilder,
+    StringSelectMenuBuilder,
+    ButtonStyle,
+    EmbedBuilder,
+    PermissionFlagsBits,
+    type ChatInputCommandInteraction,
+    type InteractionReplyOptions,
+} from 'discord.js';
+import { moderationLogs } from '../index.js';
+import type { ModerationLog } from '../lib/moderation.js';
+
+@ApplyOptions<Command.Options>({
+    description: "Get a user's moderation history",
+    requiredClientPermissions: [PermissionFlagsBits.ModerateMembers],
+    requiredUserPermissions: [PermissionFlagsBits.ModerateMembers],
+    runIn: [CommandOptionsRunTypeEnum.GuildAny],
+})
+export class LogsCommand extends Command {
+
+    public override async chatInputRun(interaction: ChatInputCommandInteraction) {
+        if (!interaction.inGuild()) {
+            return;
+        }
+
+        const user = interaction.options.getUser(Logs.User, true);
+        const guild = await interaction.client.guilds.fetch(interaction.guildId);
+        const member = await guild.members.fetch(user);
+
+        if (!member) {
+            await interaction.reply({
+                content: `Error: ${user} is not a member of this server`,
+                ephemeral: true,
+            });
+            return;
+        }
+
+        const userLog = await moderationLogs.findOne({
+            '_id.user': member.id,
+            '_id.guild': interaction.guildId,
+        });
+
+        if (!userLog) {
+            await interaction.reply({
+                content: `No moderation history found for ${user}`,
+                ephemeral: true,
+            });
+            return;
+        }
+
+        await interaction.deferReply({ ephemeral: true });
+
+        const cachedPages: CachedPages = { user: [], warnings: [], timeouts: [], bans: [] };
+        let logPage = 0;
+        let selectedCategory = Logs.User;
+
+        const replyOptions = async (): Promise<InteractionReplyOptions> => ({
+            embeds: [
+                new EmbedBuilder()
+                    .setTitle(`${member.displayName}'s moderation history`)
+                    .setDescription(
+                        await this.renderLogPage(
+                            selectedCategory,
+                            logPage,
+                            userLog,
+                            cachedPages
+                        )
+                    ),
+            ],
+            components: [
+                await this.selectActionRow(selectedCategory),
+                await this.buttonActionRow(logPage, await this.getLogLength(selectedCategory, userLog)),
+            ],
+        });
+        const reply = await interaction.editReply({
+            fetchReply: true,
+            ...(await replyOptions()),
+        });
+
+        const collector = reply.createMessageComponentCollector();
+        collector.on('collect', async i => {
+            await i.deferUpdate();
+            if (i.customId === Logs.ButtonPrev) {
+                logPage--;
+            } else if (i.customId === Logs.ButtonNext) {
+                logPage++;
+            } else if (i.isStringSelectMenu() && i.customId === Logs.Category) {
+                selectedCategory = i.values[0] as Logs;
+                logPage = 0;
+            }
+            await i.editReply(await replyOptions());
+        });
+    }
+
+    public override registerApplicationCommands(registry: Command.Registry) {
+        registry.registerChatInputCommand(
+            command =>
+                command
+                    .setName(this.name)
+                    .setDescription(this.description)
+                    .addUserOption(user =>
+                        user
+                            .setName(Logs.User)
+                            .setDescription('The user to view')
+                            .setRequired(true)
+                    ),
+            { idHints: [] }
+        );
+    }
+
+    private async renderLogPage(
+        selectedCategory: Logs,
+        index: number,
+        userLog: ModerationLog,
+        cache: CachedPages
+    ) {
+        switch (selectedCategory) {
+            case Logs.User:
+                return this.userPage(userLog, cache);
+            case Logs.Warnings:
+                return this.warningsPage(index, userLog, cache);
+            case Logs.Timeouts:
+                return this.timeoutsPage(index, userLog, cache);
+            case Logs.Bans:
+                return this.bansPage(index, userLog, cache);
+            default:
+                return '';
+        }
+    }
+
+    private async getLogLength(
+        selectedCategory: Logs,
+        userLog: ModerationLog,
+    ) {
+        switch (selectedCategory) {
+            case Logs.Warnings:
+                return userLog.warnings?.length || 1;
+            case Logs.Timeouts:
+                return userLog.timeouts?.length || 1;
+            case Logs.Bans:
+                return userLog.bans?.length || 1;
+            default:
+                return 1;
+        }
+    }
+
+    private async userPage(
+        userLog: ModerationLog,
+        cache: CachedPages
+    ) {
+        if (cache.user.length) {
+            return cache.user[0];
+        }
+        const page = [
+            `**Warnings:** ${userLog.warnings?.length || 0}`,
+            `**Timeouts:** ${userLog.timeouts?.length || 0}`,
+            `**Bans:** ${userLog.bans?.length || 0}`,
+        ].join('\n');
+
+        cache.user.push(page);
+        return page;
+
+    }
+
+    private async warningsPage(
+        index: number,
+        userLog: ModerationLog,
+        cache: CachedPages
+    ) {
+        if (index < cache.warnings.length) {
+            return cache.warnings[index];
+        }
+        let page = ``;
+        if (!userLog.warnings) {
+            page = `User has no warnings`;
+        } else {
+            page = [
+                bold(`Warning ${index + 1}\n`),
+                bold('Moderator:'),
+                `<@${userLog.warnings[index].user}>`,
+                bold('Date'),
+                userLog.warnings[index].date,
+                bold('Reason'),
+                userLog.warnings[index].reason,
+            ].join('\n');
+        }
+
+        cache.warnings.push(page);
+        return page;
+    }
+
+    private async timeoutsPage(
+        index: number,
+        userLog: ModerationLog,
+        cache: CachedPages
+    ) {
+        if (index < cache.timeouts.length) {
+            return cache.timeouts[index];
+        }
+        let page = ``;
+        if (!userLog.timeouts) {
+            page = `User has no timeouts`;
+        } else {
+            page = [
+                bold(`Timeout ${index + 1}\n`),
+                bold('Moderator:'),
+                `<@${userLog.timeouts[index].user}>`,
+                bold('Date'),
+                userLog.timeouts[index].date,
+                bold('Reason'),
+                userLog.timeouts[index].reason,
+            ].join('\n');
+        }
+
+        cache.timeouts.push(page);
+        return page;
+    }
+
+    private async bansPage(
+        index: number,
+        userLog: ModerationLog,
+        cache: CachedPages
+    ) {
+        if (index < cache.bans.length) {
+            return cache.bans[index];
+        }
+        let page = ``;
+        if (!userLog.bans) {
+            page = `User has no bans`;
+        } else {
+            page = [
+                bold(`Ban ${index + 1}\n`),
+                bold('Moderator:'),
+                `<@${userLog.bans[index].user}>`,
+                bold('Date'),
+                userLog.bans[index].date,
+                bold('Reason'),
+                userLog.bans[index].reason,
+            ].join('\n');
+        }
+
+        cache.warnings.push(page);
+        return page;
+    }
+
+    private async selectActionRow(selectedCategory: Logs) {
+        return new ActionRowBuilder<StringSelectMenuBuilder>().setComponents(
+            new StringSelectMenuBuilder()
+                .setCustomId(Logs.Category)
+                .addOptions([
+                    {
+                        label: "User",
+                        description: "User's information",
+                        value: Logs.User,
+                        default: selectedCategory === Logs.User,
+                    },
+                    {
+                        label: "Warnings",
+                        description: "Warning history",
+                        value: Logs.Warnings,
+                        default: selectedCategory === Logs.Warnings,
+                    },
+                    {
+                        label: "Timeouts",
+                        description: "Timeout history",
+                        value: Logs.Timeouts,
+                        default: selectedCategory === Logs.Timeouts,
+                    },
+                    {
+                        label: "Bans",
+                        description: "Ban history",
+                        value: Logs.Bans,
+                        default: selectedCategory === Logs.Bans,
+                    },
+                ]),
+        );
+    }
+
+    private async buttonActionRow(
+        page: number,
+        logsLength: number,
+
+    ) {
+        const isLastPage =
+            page === logsLength - 1;
+        return new ActionRowBuilder<ButtonBuilder>().setComponents(
+            new ButtonBuilder()
+                .setCustomId(Logs.ButtonPrev)
+                .setStyle(ButtonStyle.Primary)
+                .setEmoji('◀️')
+                .setDisabled(page === 0),
+            new ButtonBuilder()
+                .setCustomId(Logs.ButtonNext)
+                .setStyle(ButtonStyle.Primary)
+                .setEmoji('▶️')
+                .setDisabled(isLastPage)
+        );
+    }
+}
+
+interface CachedPages {
+    user: string[];
+    warnings: string[];
+    timeouts: string[];
+    bans: string[];
+}
+
+enum Logs {
+    User = 'user',
+    Warnings = 'warnings',
+    Timeouts = 'timeouts',
+    Bans = 'bans',
+    Title = 'title',
+    ButtonPrev = 'prev',
+    ButtonNext = 'next',
+    Category = 'category',
+}

--- a/src/commands/modlogs.ts
+++ b/src/commands/modlogs.ts
@@ -8,6 +8,7 @@ import {
     ButtonStyle,
     EmbedBuilder,
     PermissionFlagsBits,
+    userMention,
     type ChatInputCommandInteraction,
     type InteractionReplyOptions,
 } from 'discord.js';
@@ -16,11 +17,10 @@ import type { ModerationLog } from '../lib/moderation.js';
 
 @ApplyOptions<Command.Options>({
     description: "Get a user's moderation history",
-    requiredClientPermissions: [PermissionFlagsBits.ModerateMembers],
     requiredUserPermissions: [PermissionFlagsBits.ModerateMembers],
     runIn: [CommandOptionsRunTypeEnum.GuildAny],
 })
-export class LogsCommand extends Command {
+export class ModLogsCommand extends Command {
 
     public override async chatInputRun(interaction: ChatInputCommandInteraction) {
         if (!interaction.inGuild()) {
@@ -51,6 +51,10 @@ export class LogsCommand extends Command {
             });
             return;
         }
+
+        userLog.warnings?.reverse();
+        userLog.timeouts?.reverse();
+        userLog.bans?.reverse();
 
         await interaction.deferReply({ ephemeral: true });
 
@@ -178,14 +182,15 @@ export class LogsCommand extends Command {
         if (!userLog.warnings) {
             page = `User has no warnings`;
         } else {
+            const { user, date, reason } = userLog.warnings[index];
             page = [
-                bold(`Warning ${index + 1}\n`),
+                bold(`Warning #${userLog.warnings.length - index}\n`),
                 bold('Moderator:'),
-                `<@${userLog.warnings[index].user}>`,
+                userMention(user),
                 bold('Date'),
-                userLog.warnings[index].date,
+                date,
                 bold('Reason'),
-                userLog.warnings[index].reason,
+                reason,
             ].join('\n');
         }
 
@@ -205,16 +210,17 @@ export class LogsCommand extends Command {
         if (!userLog.timeouts) {
             page = `User has no timeouts`;
         } else {
+            const { user, date, duration, reason } = userLog.timeouts[index];
             page = [
-                bold(`Timeout ${index + 1}\n`),
+                bold(`Timeout #${userLog.timeouts.length - index}\n`),
                 bold('Moderator:'),
-                `<@${userLog.timeouts[index].user}>`,
+                userMention(user),
                 bold('Date'),
-                userLog.timeouts[index].date,
+                date,
                 bold('Duration'),
-                userLog.timeouts[index].duration,
+                duration,
                 bold('Reason'),
-                userLog.timeouts[index].reason,
+                reason,
             ].join('\n');
         }
 
@@ -234,14 +240,15 @@ export class LogsCommand extends Command {
         if (!userLog.bans) {
             page = `User has no bans`;
         } else {
+            const { user, date, reason } = userLog.bans[index];
             page = [
-                bold(`Ban ${index + 1}\n`),
+                bold(`Ban #${userLog.bans.length - index}\n`),
                 bold('Moderator:'),
-                `<@${userLog.bans[index].user}>`,
+                userMention(user),
                 bold('Date'),
-                userLog.bans[index].date,
+                date,
                 bold('Reason'),
-                userLog.bans[index].reason,
+                reason,
             ].join('\n');
         }
 

--- a/src/commands/modlogs.ts
+++ b/src/commands/modlogs.ts
@@ -52,10 +52,6 @@ export class ModLogsCommand extends Command {
             return;
         }
 
-        userLog.warnings?.reverse();
-        userLog.timeouts?.reverse();
-        userLog.bans?.reverse();
-
         await interaction.deferReply({ ephemeral: true });
 
         const cachedPages: CachedPages = { user: [], warnings: [], timeouts: [], bans: [] };

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -10,7 +10,7 @@ import {
 import { Color } from '../lib/embeds.js';
 import { messageLogger, moderationLogs } from "../index.js";
 import { DurationUnit } from "../lib/duration.js";
-import type { timeoutLog } from '../lib/moderation.js';
+import type { TimeoutLog } from '../lib/moderation.js';
 
 @ApplyOptions<Command.Options>({
   description: "Timeout user",
@@ -28,7 +28,7 @@ export class TimeoutCommand extends Command {
     const user = interaction.options.getUser(Option.User, true);
     const duration = interaction.options.getNumber(Option.Duration, true);
     const unit = interaction.options.getString(Option.Unit, true);
-    const reason = interaction.options.getString(Option.Reason);
+    const reason = interaction.options.getString(Option.Reason, true);
 
     const guild = await interaction.client.guilds.fetch(interaction.guildId);
     const member = await guild.members.fetch(user);
@@ -59,17 +59,9 @@ export class TimeoutCommand extends Command {
       return;
     }
 
-    if (!reason) {
-      await interaction.reply({
-        content: `Error: Timeouts require a reason.`,
-        ephemeral: true,
-      });
-      return;
-    }
-
     const filter = { '_id.guild': interaction.guildId, '_id.user': member.id };
 
-    const userTimeout: timeoutLog = {
+    const userTimeout: TimeoutLog = {
       date: new Date(),
       duration: readableDuration,
       user: interaction.user.id,
@@ -93,7 +85,7 @@ export class TimeoutCommand extends Command {
       .setColor(Color.Red)
       .setTitle('You Have Been Timed Out')
       .addFields(
-        { name: 'Server', value: `${guild.name}` },
+        { name: 'Server', value: guild.name },
         { name: 'Reason', value: reason },
         { name: 'Duration', value: readableDuration },
         {
@@ -115,7 +107,7 @@ export class TimeoutCommand extends Command {
       ephemeral: true,
     });
 
-    messageLogger.logMemberTimeout(
+    await messageLogger.logMemberTimeout(
       member,
       interaction.user,
       durationMilliseconds,

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -70,7 +70,7 @@ export class TimeoutCommand extends Command {
 
     const update = {
       $push: {
-        timeouts: userTimeout
+        timeouts: { $each: [userTimeout], $position: 0 }
       }
     };
 

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -78,7 +78,7 @@ export class TimeoutCommand extends Command {
 
     const update = {
       $push: {
-        timeout: userTimeout
+        timeouts: userTimeout
       }
     };
 

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -67,7 +67,7 @@ export class TimeoutCommand extends Command {
       return;
     }
 
-    const filter = { '_id.guild': interaction.guildId!, '_id.user': member.id };
+    const filter = { '_id.guild': interaction.guildId, '_id.user': member.id };
 
     const userTimeout: timeoutLog = {
       date: new Date(),

--- a/src/commands/timeout.ts
+++ b/src/commands/timeout.ts
@@ -151,7 +151,7 @@ export class TimeoutCommand extends Command {
           .addStringOption((reason) =>
             reason
               .setName(Option.Reason)
-              .setDescription("The reason for timing them out, if any")
+              .setDescription("The reason for timing them out")
               .setRequired(true),
           ),
       { idHints: ["988533580663779369", "984094351170883605"] },

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -53,7 +53,7 @@ export class WarnCommand extends Command {
 
         const update = {
             $push: {
-                warning: userWarning
+                warnings: userWarning
             }
         };
 

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -52,7 +52,7 @@ export class WarnCommand extends Command {
 
         const update = {
             $push: {
-                warnings: userWarning
+                warnings: { $each: [userWarning], $position: 0 }
             }
         };
 

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -1,0 +1,118 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Command, CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import {
+    PermissionFlagsBits,
+    EmbedBuilder,
+    type ChatInputCommandInteraction,
+} from 'discord.js';
+import { Color } from '../lib/embeds.js';
+import { messageLogger, moderationLogs } from '../index.js';
+import type { warnLog } from '../lib/moderation.js';
+
+@ApplyOptions<Command.Options>({
+    description: 'Warn user',
+    requiredClientPermissions: [PermissionFlagsBits.ModerateMembers],
+    requiredUserPermissions: [PermissionFlagsBits.ModerateMembers],
+    runIn: [CommandOptionsRunTypeEnum.GuildAny],
+})
+export class WarnCommand extends Command {
+
+    public override async chatInputRun(interaction: ChatInputCommandInteraction) {
+        if (!interaction.inGuild()) {
+            return;
+        }
+        const user = interaction.options.getUser(Option.User, true);
+        const reason = interaction.options.getString(Option.Reason);
+
+        const guild = await interaction.client.guilds.fetch(interaction.guildId);
+        const member = await guild.members.fetch(user);
+
+        if (!member) {
+            await interaction.reply({
+                content: `Error: ${user} is not a member of this server`,
+                ephemeral: true,
+            });
+            return;
+        }
+
+        if (!reason) {
+            await interaction.reply({
+                content: `Error: Warnings require a reason.`,
+                ephemeral: true,
+            });
+            return;
+        }
+
+        const filter = { '_id.guild': interaction.guildId!, '_id.user': member.id };
+
+        const userWarning: warnLog = {
+            date: new Date(),
+            user: interaction.user.id,
+            reason: reason
+        };
+
+        const update = {
+            $push: {
+                warning: userWarning
+            }
+        };
+
+        const options = { upsert: true };
+
+        moderationLogs.findOneAndUpdate(filter, update, options);
+
+        const ephemeralEmbed = new EmbedBuilder()
+            .setColor(Color.Red)
+            .setDescription(`${user.tag} warned`)
+
+        await interaction.reply({
+            embeds: [ephemeralEmbed],
+            ephemeral: true,
+        });
+
+        const embed = new EmbedBuilder()
+            .setColor(Color.Red)
+            .setTitle('You Have Been Warned')
+            .addFields(
+                { name: 'Server', value: `${guild.name}` },
+                { name: 'Reason', value: reason },
+            )
+            .setTimestamp(interaction.createdTimestamp);
+
+        await member.send({ embeds: [embed] });
+
+        messageLogger.logMemberWarning(
+            member,
+            interaction.user,
+            reason,
+            interaction.createdTimestamp
+        );
+    }
+
+    public override registerApplicationCommands(registry: Command.Registry) {
+        registry.registerChatInputCommand(
+            command =>
+                command
+                    .setName(this.name)
+                    .setDescription(this.description)
+                    .addUserOption(user =>
+                        user
+                            .setName(Option.User)
+                            .setDescription('The user to warn')
+                            .setRequired(true)
+                    )
+                    .addStringOption(reason =>
+                        reason
+                            .setName(Option.Reason)
+                            .setDescription('The reason for warning them')
+                            .setRequired(true)
+                    ),
+            { idHints: [] }
+        );
+    }
+}
+
+enum Option {
+    User = 'user',
+    Reason = 'reason',
+}

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -43,7 +43,7 @@ export class WarnCommand extends Command {
             return;
         }
 
-        const filter = { '_id.guild': interaction.guildId!, '_id.user': member.id };
+        const filter = { '_id.guild': interaction.guildId, '_id.user': member.id };
 
         const userWarning: warnLog = {
             date: new Date(),

--- a/src/commands/warn.ts
+++ b/src/commands/warn.ts
@@ -7,11 +7,10 @@ import {
 } from 'discord.js';
 import { Color } from '../lib/embeds.js';
 import { messageLogger, moderationLogs } from '../index.js';
-import type { warnLog } from '../lib/moderation.js';
+import type { WarnLog } from '../lib/moderation.js';
 
 @ApplyOptions<Command.Options>({
     description: 'Warn user',
-    requiredClientPermissions: [PermissionFlagsBits.ModerateMembers],
     requiredUserPermissions: [PermissionFlagsBits.ModerateMembers],
     runIn: [CommandOptionsRunTypeEnum.GuildAny],
 })
@@ -22,7 +21,7 @@ export class WarnCommand extends Command {
             return;
         }
         const user = interaction.options.getUser(Option.User, true);
-        const reason = interaction.options.getString(Option.Reason);
+        const reason = interaction.options.getString(Option.Reason, true);
 
         const guild = await interaction.client.guilds.fetch(interaction.guildId);
         const member = await guild.members.fetch(user);
@@ -45,7 +44,7 @@ export class WarnCommand extends Command {
 
         const filter = { '_id.guild': interaction.guildId, '_id.user': member.id };
 
-        const userWarning: warnLog = {
+        const userWarning: WarnLog = {
             date: new Date(),
             user: interaction.user.id,
             reason: reason
@@ -74,14 +73,14 @@ export class WarnCommand extends Command {
             .setColor(Color.Red)
             .setTitle('You Have Been Warned')
             .addFields(
-                { name: 'Server', value: `${guild.name}` },
+                { name: 'Server', value: guild.name },
                 { name: 'Reason', value: reason },
             )
             .setTimestamp(interaction.createdTimestamp);
 
         await member.send({ embeds: [embed] });
 
-        messageLogger.logMemberWarning(
+        await messageLogger.logMemberWarning(
             member,
             interaction.user,
             reason,

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 import { MessageLogger } from "./lib/logging.js";
 import { SettingsManager, type GuildSettings } from "./lib/settings.js";
 import type { VerifiedMember } from "./lib/verification.js";
+import type { ModerationLog } from './lib/moderation.js';
 
 const mongoClient = new MongoClient(mongoUrl);
 const database = mongoClient.db();
@@ -19,6 +20,7 @@ const channelMessages = database.collection<ChannelMessages>("channels");
 const guildSettings = database.collection<GuildSettings>("settings");
 export const messageCounts = database.collection<MessageCount>("messages");
 export const verifiedMembers = database.collection<VerifiedMember>("members");
+export const moderationLogs = database.collection<ModerationLog>('moderation');
 
 export const messageCounter = new MessageCounter(
   channelMessages,

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -58,7 +58,7 @@ export class MessageLogger {
     const embed = new EmbedBuilder()
       .setColor(Color.Red)
       .setTitle('Member Warned')
-      .setThumbnail((member ?? member).displayAvatarURL())
+      .setThumbnail(member.displayAvatarURL())
       .addFields(
         { name: 'Member', value: `${member} (${member.user.tag})` },
         { name: 'Performed By', value: `${executor}`, inline: true },
@@ -87,7 +87,7 @@ export class MessageLogger {
     const embed = new EmbedBuilder()
       .setColor(Color.Red)
       .setTitle('Member Timed Out')
-      .setThumbnail((member ?? member).displayAvatarURL())
+      .setThumbnail(member.displayAvatarURL())
       .addFields(
         { name: "Member", value: `${member} (${member.user.tag})` },
         { name: "Performed By", value: `${executor}`, inline: true },
@@ -121,7 +121,7 @@ export class MessageLogger {
     const embed = new EmbedBuilder()
       .setColor(Color.Red)
       .setTitle('Member Banned')
-      .setThumbnail((member ?? member).displayAvatarURL())
+      .setThumbnail(member.displayAvatarURL())
       .addFields(
         { name: 'Member', value: `${member} (${member.user.tag})` },
         { name: 'Performed By', value: `${executor}`, inline: true },

--- a/src/lib/logging.ts
+++ b/src/lib/logging.ts
@@ -19,7 +19,7 @@ import type { SettingsManager } from "./settings.js";
 import { userUrl } from "./user.js";
 
 export class MessageLogger {
-  public constructor(private readonly settingsManager: SettingsManager) {}
+  public constructor(private readonly settingsManager: SettingsManager) { }
 
   public async logMessageDelete(
     message: Message | PartialMessage,
@@ -44,6 +44,32 @@ export class MessageLogger {
     );
   }
 
+  public async logMemberWarning(
+    member: GuildMember,
+    executor: User,
+    reason: string,
+    executedTimestamp: number
+  ) {
+    const logChannel = await this.channelForGuild(member.guild);
+    if (!logChannel) {
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(Color.Red)
+      .setTitle('Member Warned')
+      .setThumbnail((member ?? member).displayAvatarURL())
+      .addFields(
+        { name: 'Member', value: `${member} (${member.user.tag})` },
+        { name: 'Performed By', value: `${executor}`, inline: true },
+        { name: 'Warned For', value: reason },
+      )
+      .setFooter({ text: `User ID: ${member.id}` })
+      .setTimestamp(executedTimestamp);
+
+    await logChannel.send({ embeds: [embed] });
+  }
+
   public async logMemberTimeout(
     member: GuildMember,
     executor: User,
@@ -60,7 +86,8 @@ export class MessageLogger {
     const expiration = new Date(executedTimestamp + durationMilliseconds);
     const embed = new EmbedBuilder()
       .setColor(Color.Red)
-      .setTitle("Member Timed Out")
+      .setTitle('Member Timed Out')
+      .setThumbnail((member ?? member).displayAvatarURL())
       .addFields(
         { name: "Member", value: `${member} (${member.user.tag})` },
         { name: "Performed By", value: `${executor}`, inline: true },
@@ -76,6 +103,32 @@ export class MessageLogger {
     if (reason) {
       embed.addFields({ name: "Reason", value: reason });
     }
+
+    await logChannel.send({ embeds: [embed] });
+  }
+
+  public async logMemberBan(
+    member: GuildMember,
+    executor: User,
+    reason: string,
+    executedTimestamp: number
+  ) {
+    const logChannel = await this.channelForGuild(member.guild);
+    if (!logChannel) {
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setColor(Color.Red)
+      .setTitle('Member Banned')
+      .setThumbnail((member ?? member).displayAvatarURL())
+      .addFields(
+        { name: 'Member', value: `${member} (${member.user.tag})` },
+        { name: 'Performed By', value: `${executor}`, inline: true },
+        { name: 'Reason', value: reason },
+      )
+      .setFooter({ text: `User ID: ${member.id}` })
+      .setTimestamp(executedTimestamp);
 
     await logChannel.send({ embeds: [embed] });
   }

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -24,5 +24,5 @@ export interface ModerationLog {
     };
     warning?: [warnLog];
     timeout?: [timeoutLog];
-    ban?: [bans: banLog];
+    ban?: [banLog];
 }

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -1,17 +1,17 @@
-export interface warnLog {
+export interface WarnLog {
     date: Date;
     user: string;
     reason: string;
 }
 
-export interface timeoutLog {
+export interface TimeoutLog {
     date: Date;
     duration: string;
     user: string;
     reason: string;
 }
 
-export interface banLog {
+export interface BanLog {
     date: Date;
     user: string;
     reason: string;
@@ -22,7 +22,7 @@ export interface ModerationLog {
         guild: string;
         user: string;
     };
-    warnings?: [warnLog];
-    timeouts?: [timeoutLog];
-    bans?: [banLog];
+    warnings?: [WarnLog];
+    timeouts?: [TimeoutLog];
+    bans?: [BanLog];
 }

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -1,0 +1,28 @@
+export interface warnLog {
+    date: Date;
+    user: string;
+    reason: string;
+}
+
+export interface timeoutLog {
+    date: Date;
+    duration: string;
+    user: string;
+    reason: string;
+}
+
+export interface banLog {
+    date: Date;
+    user: string;
+    reason: string;
+}
+
+export interface ModerationLog {
+    _id: {
+        guild: string;
+        user: string;
+    };
+    warning?: [warnLog];
+    timeout?: [timeoutLog];
+    ban?: [bans: banLog];
+}

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -22,7 +22,7 @@ export interface ModerationLog {
         guild: string;
         user: string;
     };
-    warning?: [warnLog];
-    timeout?: [timeoutLog];
-    ban?: [banLog];
+    warnings?: [warnLog];
+    timeouts?: [timeoutLog];
+    bans?: [banLog];
 }


### PR DESCRIPTION
Added 2 new moderation commands `warn` and `ban`

Added `Moderation` to MongoDB for `warn`, `timeout`, and `ban` to store logs. 

Required `Reason` to be input on `timeout` command to allow for more detailed logs

Added `logs` command for moderators to be able to see infraction history of users